### PR TITLE
Group tyres by make then type, with retired tyres at bottom

### DIFF
--- a/src/routes/Tyres.svelte
+++ b/src/routes/Tyres.svelte
@@ -14,9 +14,41 @@
   import './action-buttons.css';
 
   let tyres = [];
+  let groupedTyres = []; // Array of { make, types: [{ type, tyres: [...] }] }
+  let retiredTyres = [];
   let loading = true;
   let error = '';
   let menuMap = {}; // Store menu instances for each row
+
+  const sortByCreatedAt = (a, b) => {
+    const aDate = a.createdAt?.toDate ? a.createdAt.toDate() : new Date(a.createdAt);
+    const bDate = b.createdAt?.toDate ? b.createdAt.toDate() : new Date(b.createdAt);
+    return bDate - aDate;
+  };
+
+  const buildGroupedTyres = (allTyres) => {
+    const active = allTyres.filter(t => !t.retired);
+    retiredTyres = allTyres.filter(t => t.retired).sort(sortByCreatedAt);
+
+    // Group active tyres by make, then by type
+    const makeMap = {};
+    for (const tyre of active) {
+      const make = tyre.make || 'Unknown';
+      const type = tyre.type || 'Unknown';
+      if (!makeMap[make]) makeMap[make] = {};
+      if (!makeMap[make][type]) makeMap[make][type] = [];
+      makeMap[make][type].push(tyre);
+    }
+
+    // Convert to array structure, sorting each group internally
+    groupedTyres = Object.keys(makeMap).sort().map(make => ({
+      make,
+      types: Object.keys(makeMap[make]).sort().map(type => ({
+        type,
+        tyres: makeMap[make][type].sort(sortByCreatedAt)
+      }))
+    }));
+  };
 
   const loadTyres = async () => {
     try {
@@ -30,18 +62,8 @@
       // Merge tyre data with statistics
       const tyresWithStats = mergeItemsWithStats(rawTyres, tyreStats);
       
-      // Sort tyres: active tyres first (by createdAt desc), then retired tyres (by createdAt desc)
-      tyres = tyresWithStats.sort((a, b) => {
-        // If one is retired and the other isn't, retired goes to bottom
-        if (a.retired !== b.retired) {
-          return a.retired ? 1 : -1;
-        }
-        
-        // Both have same retirement status, sort by createdAt (most recent first)
-        const aDate = a.createdAt?.toDate ? a.createdAt.toDate() : new Date(a.createdAt);
-        const bDate = b.createdAt?.toDate ? b.createdAt.toDate() : new Date(b.createdAt);
-        return bDate - aDate;
-      });
+      tyres = tyresWithStats;
+      buildGroupedTyres(tyresWithStats);
     } catch (err) {
       error = err.message;
     } finally {
@@ -130,90 +152,179 @@
       <Button href="/tyres/new" tag="a" use={[link]} variant="raised" color="primary">Add Tyre</Button>
     </div>
   {:else}
-    <div class="table-container">
-      <DataTable style="width: 100%;">
-        <Head>
-          <Row>
-            <Cell>Name</Cell>
-            <Cell>Make </Cell>
-            <Cell>Laps</Cell>
-            <Cell class="col-sessions">Sessions</Cell>
-            <Cell class="col-status">Status</Cell>
-            <Cell class="actions-header col-actions">Actions</Cell>
-          </Row>
-        </Head>
-        <Body>
-          {#each tyres as tyre (tyre.id)}
-            <Row class="tyre-row {tyre.retired ? 'retired-row' : ''}">
-              <div 
-                class="clickable-row {tyre.sessions > 0 ? 'has-sessions' : ''}" 
-                on:click={() => handleRowClick(tyre)} 
-                on:keydown={(e) => e.key === 'Enter' && handleRowClick(tyre)} 
-                tabindex="0" 
-                role="button"
-              >
-                <Cell>{tyre.name}</Cell>
-                <Cell>{tyre.make} / {tyre.type}</Cell>
-                <Cell>{tyre.totalLaps}</Cell>
-                <Cell class="col-sessions">{tyre.sessions}</Cell>
-                <Cell class="col-status">
-                  {#if tyre.retired}
-                    <span class="retired-badge">Retired</span>
-                  {:else}
-                    <span class="active-badge">Active</span>
-                  {/if}
-                </Cell>
-                <Cell class="col-actions">
-                  <div class="action-buttons desktop-actions">
-                    <a href="/tyres/{tyre.id}" use:link class="text-button" on:click|stopPropagation>
-                      Edit
-                    </a>
-                    {#if !tyre.retired}
-                      <button on:click|stopPropagation|preventDefault={() => handleRetire(tyre.id)} class="text-button retire-button">
-                        Retire
-                      </button>
-                    {/if}
-                    <button on:click|stopPropagation|preventDefault={() => handleDelete(tyre.id)} class="text-button delete-button">
-                      Delete
-                    </button>
-                  </div>
-                  <div class="kebab-menu-container" on:click|stopPropagation on:keydown|stopPropagation role="none">
-                    <div class="menu-surface-anchor">
-                      <button 
-                        class="kebab-button-simple" 
-                        on:click={() => menuMap[tyre.id]?.setOpen(true)}
-                        aria-label="More actions"
-                      >
-                        ⋮
-                      </button>
-                      <Menu bind:this={menuMap[tyre.id]}>
-                        <List>
-                          <Item onSMUIAction={() => handleMenuItemClick('edit', tyre.id)}>
-                            <Text>Edit</Text>
-                          </Item>
-                          {#if !tyre.retired}
-                            <Item onSMUIAction={() => handleMenuItemClick('retire', tyre.id)}>
-                              <Text>Retire</Text>
-                            </Item>
-                          {/if}
-                          <Item onSMUIAction={() => handleMenuItemClick('delete', tyre.id)}>
-                            <Text class="delete-text">Delete</Text>
-                          </Item>
-                        </List>
-                      </Menu>
+    {#each groupedTyres as makeGroup}
+      <div class="group-section">
+        <h2 class="make-header">{makeGroup.make}</h2>
+        {#each makeGroup.types as typeGroup}
+          <h3 class="type-header">{typeGroup.type}</h3>
+          <div class="table-container">
+            <DataTable style="width: 100%;">
+              <Head>
+                <Row>
+                  <Cell>Name</Cell>
+                  <Cell>Laps</Cell>
+                  <Cell class="col-sessions">Sessions</Cell>
+                  <Cell class="actions-header col-actions">Actions</Cell>
+                </Row>
+              </Head>
+              <Body>
+                {#each typeGroup.tyres as tyre (tyre.id)}
+                  <Row class="tyre-row">
+                    <div 
+                      class="clickable-row {tyre.sessions > 0 ? 'has-sessions' : ''}" 
+                      on:click={() => handleRowClick(tyre)} 
+                      on:keydown={(e) => e.key === 'Enter' && handleRowClick(tyre)} 
+                      tabindex="0" 
+                      role="button"
+                    >
+                      <Cell>{tyre.name}</Cell>
+                      <Cell>{tyre.totalLaps}</Cell>
+                      <Cell class="col-sessions">{tyre.sessions}</Cell>
+                      <Cell class="col-actions">
+                        <div class="action-buttons desktop-actions">
+                          <a href="/tyres/{tyre.id}" use:link class="text-button" on:click|stopPropagation>
+                            Edit
+                          </a>
+                          <button on:click|stopPropagation|preventDefault={() => handleRetire(tyre.id)} class="text-button retire-button">
+                            Retire
+                          </button>
+                          <button on:click|stopPropagation|preventDefault={() => handleDelete(tyre.id)} class="text-button delete-button">
+                            Delete
+                          </button>
+                        </div>
+                        <div class="kebab-menu-container" on:click|stopPropagation on:keydown|stopPropagation role="none">
+                          <div class="menu-surface-anchor">
+                            <button 
+                              class="kebab-button-simple" 
+                              on:click={() => menuMap[tyre.id]?.setOpen(true)}
+                              aria-label="More actions"
+                            >
+                              ⋮
+                            </button>
+                            <Menu bind:this={menuMap[tyre.id]}>
+                              <List>
+                                <Item onSMUIAction={() => handleMenuItemClick('edit', tyre.id)}>
+                                  <Text>Edit</Text>
+                                </Item>
+                                <Item onSMUIAction={() => handleMenuItemClick('retire', tyre.id)}>
+                                  <Text>Retire</Text>
+                                </Item>
+                                <Item onSMUIAction={() => handleMenuItemClick('delete', tyre.id)}>
+                                  <Text class="delete-text">Delete</Text>
+                                </Item>
+                              </List>
+                            </Menu>
+                          </div>
+                        </div>
+                      </Cell>
                     </div>
+                  </Row>
+                {/each}
+              </Body>
+            </DataTable>
+          </div>
+        {/each}
+      </div>
+    {/each}
+
+    {#if retiredTyres.length > 0}
+      <div class="group-section retired-section">
+        <h2 class="make-header retired-header">Retired</h2>
+        <div class="table-container">
+          <DataTable style="width: 100%;">
+            <Head>
+              <Row>
+                <Cell>Name</Cell>
+                <Cell>Make / Type</Cell>
+                <Cell>Laps</Cell>
+                <Cell class="col-sessions">Sessions</Cell>
+                <Cell class="actions-header col-actions">Actions</Cell>
+              </Row>
+            </Head>
+            <Body>
+              {#each retiredTyres as tyre (tyre.id)}
+                <Row class="tyre-row retired-row">
+                  <div 
+                    class="clickable-row {tyre.sessions > 0 ? 'has-sessions' : ''}" 
+                    on:click={() => handleRowClick(tyre)} 
+                    on:keydown={(e) => e.key === 'Enter' && handleRowClick(tyre)} 
+                    tabindex="0" 
+                    role="button"
+                  >
+                    <Cell>{tyre.name}</Cell>
+                    <Cell>{tyre.make} / {tyre.type}</Cell>
+                    <Cell>{tyre.totalLaps}</Cell>
+                    <Cell class="col-sessions">{tyre.sessions}</Cell>
+                    <Cell class="col-actions">
+                      <div class="action-buttons desktop-actions">
+                        <a href="/tyres/{tyre.id}" use:link class="text-button" on:click|stopPropagation>
+                          Edit
+                        </a>
+                        <button on:click|stopPropagation|preventDefault={() => handleDelete(tyre.id)} class="text-button delete-button">
+                          Delete
+                        </button>
+                      </div>
+                      <div class="kebab-menu-container" on:click|stopPropagation on:keydown|stopPropagation role="none">
+                        <div class="menu-surface-anchor">
+                          <button 
+                            class="kebab-button-simple" 
+                            on:click={() => menuMap[tyre.id]?.setOpen(true)}
+                            aria-label="More actions"
+                          >
+                            ⋮
+                          </button>
+                          <Menu bind:this={menuMap[tyre.id]}>
+                            <List>
+                              <Item onSMUIAction={() => handleMenuItemClick('edit', tyre.id)}>
+                                <Text>Edit</Text>
+                              </Item>
+                              <Item onSMUIAction={() => handleMenuItemClick('delete', tyre.id)}>
+                                <Text class="delete-text">Delete</Text>
+                              </Item>
+                            </List>
+                          </Menu>
+                        </div>
+                      </div>
+                    </Cell>
                   </div>
-                </Cell>
-              </div>
-            </Row>
-          {/each}
-        </Body>
-      </DataTable>
-    </div>
+                </Row>
+              {/each}
+            </Body>
+          </DataTable>
+        </div>
+      </div>
+    {/if}
   {/if}
 </div>
 
 <style>
+  /* Group section styles */
+  .group-section {
+    margin-bottom: 2rem;
+  }
+
+  .make-header {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin: 1.5rem 0 0.5rem;
+    color: #333;
+  }
+
+  .type-header {
+    font-size: 1rem;
+    font-weight: 500;
+    margin: 0.75rem 0 0.25rem;
+    color: #666;
+  }
+
+  .retired-header {
+    color: #9e9e9e;
+  }
+
+  .retired-section {
+    opacity: 0.6;
+  }
+
   /* Tyre-specific table styles */
   :global(.tyre-row) {
     position: relative;
@@ -249,27 +360,6 @@
 
   :global(.actions-header) {
     text-align: right;
-  }
-
-  /* Tyre status badges */
-  .retired-badge {
-    display: inline-block;
-    padding: 2px 8px;
-    background-color: #9e9e9e;
-    color: white;
-    border-radius: 12px;
-    font-size: 12px;
-    font-weight: 500;
-  }
-
-  .active-badge {
-    display: inline-block;
-    padding: 2px 8px;
-    background-color: #4caf50;
-    color: white;
-    border-radius: 12px;
-    font-size: 12px;
-    font-weight: 500;
   }
 
   /* Kebab menu */
@@ -320,12 +410,6 @@
   /* Responsive column hiding */
   @media (max-width: 768px) {
     :global(.col-sessions) {
-      display: none;
-    }
-  }
-
-  @media (max-width: 640px) {
-    :global(.col-status) {
       display: none;
     }
   }


### PR DESCRIPTION
## Summary

Restructures the Tyres page to group active tyres hierarchically by **make** (h2 header), then by **type** e.g. Dry/Slick (h3 header), with each sub-group rendered in its own DataTable. Retired tyres are collected into a separate "Retired" section at the bottom with reduced opacity.

Key changes:
- Replaced the previous single-table layout (which used inline group-header rows) with separate DataTables under make/type section headers
- Extracted grouping logic into a `buildGroupedTyres` function and `sortByCreatedAt` helper for clarity
- Removed the "Make" and "Status" columns from active tyre tables (now conveyed by the group headers)
- Retired tyres table retains a "Make / Type" column since they're not grouped
- Removed status badge styles, group-header-row styles, and alternating-row overrides (no longer needed)

## Review & Testing Checklist for Human
- [ ] **Double opacity on retired rows**: The `.retired-section` applies `opacity: 0.6` to the whole section, and `.retired-row td` applies another `opacity: 0.6`. This compounds to ~0.36 effective opacity — verify this isn't too faded, or remove one of the two opacity rules
- [ ] **Visual check**: Run `npm run dev:mock`, navigate to the Tyres page, and verify the grouping renders correctly with multiple makes and types
- [ ] **Responsive behavior**: Check the kebab menu and column hiding at mobile breakpoints (480px, 768px) — the 640px breakpoint for `.col-status` was removed since the status column no longer exists
- [ ] **Edge case — all tyres retired**: Confirm the page still renders correctly when there are no active tyres (only the retired section should appear)

### Notes
- The `formatDate` function and `tyres` variable remain in the script but are unused — both were unused before this change as well
- This PR resolved merge conflicts with `main` which had a different grouping approach (flat array with sentinel header objects in a single table). The separate-tables approach was kept as it provides cleaner visual separation between groups.

Link to Devin session: https://app.devin.ai/sessions/bf8f7153141047218efd8255a1f9184e
Requested by: @ColinEberhardt